### PR TITLE
Inline Implementation Details

### DIFF
--- a/GamepadMotion.hpp
+++ b/GamepadMotion.hpp
@@ -265,7 +265,7 @@ private:
 
 namespace GamepadMotionHelpers
 {
-	Quat::Quat()
+	inline Quat::Quat()
 	{
 		w = 1.0f;
 		x = 0.0f;
@@ -273,7 +273,7 @@ namespace GamepadMotionHelpers
 		z = 0.0f;
 	}
 
-	Quat::Quat(float inW, float inX, float inY, float inZ)
+	inline Quat::Quat(float inW, float inX, float inY, float inZ)
 	{
 		w = inW;
 		x = inX;
@@ -281,14 +281,14 @@ namespace GamepadMotionHelpers
 		z = inZ;
 	}
 
-	static Quat AngleAxis(float inAngle, float inX, float inY, float inZ)
+	inline static Quat AngleAxis(float inAngle, float inX, float inY, float inZ)
 	{
 		Quat result = Quat(cosf(inAngle * 0.5f), inX, inY, inZ);
 		result.Normalize();
 		return result;
 	}
 
-	void Quat::Set(float inW, float inX, float inY, float inZ)
+	inline void Quat::Set(float inW, float inX, float inY, float inZ)
 	{
 		w = inW;
 		x = inX;
@@ -296,7 +296,7 @@ namespace GamepadMotionHelpers
 		z = inZ;
 	}
 
-	Quat& Quat::operator*=(const Quat& rhs)
+	inline Quat& Quat::operator*=(const Quat& rhs)
 	{
 		Set(w * rhs.w - x * rhs.x - y * rhs.y - z * rhs.z,
 			w * rhs.x + x * rhs.w + y * rhs.z - z * rhs.y,
@@ -305,13 +305,13 @@ namespace GamepadMotionHelpers
 		return *this;
 	}
 
-	Quat operator*(Quat lhs, const Quat& rhs)
+	inline Quat operator*(Quat lhs, const Quat& rhs)
 	{
 		lhs *= rhs;
 		return lhs;
 	}
 
-	void Quat::Normalize()
+	inline void Quat::Normalize()
 	{
 		//printf("Normalizing: %.4f, %.4f, %.4f, %.4f\n", w, x, y, z);
 		const float length = sqrtf(x * x + y * y + z * z);
@@ -332,14 +332,14 @@ namespace GamepadMotionHelpers
 		return;
 	}
 
-	Quat Quat::Normalized() const
+	inline Quat Quat::Normalized() const
 	{
 		Quat result = *this;
 		result.Normalize();
 		return result;
 	}
 
-	void Quat::Invert()
+	inline void Quat::Invert()
 	{
 		x = -x;
 		y = -y;
@@ -347,52 +347,52 @@ namespace GamepadMotionHelpers
 		return;
 	}
 
-	Quat Quat::Inverse() const
+	inline Quat Quat::Inverse() const
 	{
 		Quat result = *this;
 		result.Invert();
 		return result;
 	}
 
-	Vec::Vec()
+	inline Vec::Vec()
 	{
 		x = 0.0f;
 		y = 0.0f;
 		z = 0.0f;
 	}
 
-	Vec::Vec(float inValue)
+	inline Vec::Vec(float inValue)
 	{
 		x = inValue;
 		y = inValue;
 		z = inValue;
 	}
 
-	Vec::Vec(float inX, float inY, float inZ)
+	inline Vec::Vec(float inX, float inY, float inZ)
 	{
 		x = inX;
 		y = inY;
 		z = inZ;
 	}
 
-	void Vec::Set(float inX, float inY, float inZ)
+	inline void Vec::Set(float inX, float inY, float inZ)
 	{
 		x = inX;
 		y = inY;
 		z = inZ;
 	}
 
-	float Vec::Length() const
+	inline float Vec::Length() const
 	{
 		return sqrtf(x * x + y * y + z * z);
 	}
 
-	float Vec::LengthSquared() const
+	inline float Vec::LengthSquared() const
 	{
 		return x * x + y * y + z * z;
 	}
 
-	void Vec::Normalize()
+	inline void Vec::Normalize()
 	{
 		const float length = Length();
 		if (length == 0.0)
@@ -407,131 +407,131 @@ namespace GamepadMotionHelpers
 		return;
 	}
 
-	Vec Vec::Normalized() const
+	inline Vec Vec::Normalized() const
 	{
 		Vec result = *this;
 		result.Normalize();
 		return result;
 	}
 
-	Vec& Vec::operator+=(const Vec& rhs)
+	inline Vec& Vec::operator+=(const Vec& rhs)
 	{
 		Set(x + rhs.x, y + rhs.y, z + rhs.z);
 		return *this;
 	}
 
-	Vec operator+(Vec lhs, const Vec& rhs)
+	inline Vec operator+(Vec lhs, const Vec& rhs)
 	{
 		lhs += rhs;
 		return lhs;
 	}
 
-	Vec& Vec::operator-=(const Vec& rhs)
+	inline Vec& Vec::operator-=(const Vec& rhs)
 	{
 		Set(x - rhs.x, y - rhs.y, z - rhs.z);
 		return *this;
 	}
 
-	Vec operator-(Vec lhs, const Vec& rhs)
+	inline Vec operator-(Vec lhs, const Vec& rhs)
 	{
 		lhs -= rhs;
 		return lhs;
 	}
 
-	Vec& Vec::operator*=(const float rhs)
+	inline Vec& Vec::operator*=(const float rhs)
 	{
 		Set(x * rhs, y * rhs, z * rhs);
 		return *this;
 	}
 
-	Vec operator*(Vec lhs, const float rhs)
+	inline Vec operator*(Vec lhs, const float rhs)
 	{
 		lhs *= rhs;
 		return lhs;
 	}
 
-	Vec& Vec::operator/=(const float rhs)
+	inline Vec& Vec::operator/=(const float rhs)
 	{
 		Set(x / rhs, y / rhs, z / rhs);
 		return *this;
 	}
 
-	Vec operator/(Vec lhs, const float rhs)
+	inline Vec operator/(Vec lhs, const float rhs)
 	{
 		lhs /= rhs;
 		return lhs;
 	}
 
-	Vec& Vec::operator*=(const Quat& rhs)
+	inline Vec& Vec::operator*=(const Quat& rhs)
 	{
 		Quat temp = rhs * Quat(0.0f, x, y, z) * rhs.Inverse();
 		Set(temp.x, temp.y, temp.z);
 		return *this;
 	}
 
-	Vec operator*(Vec lhs, const Quat& rhs)
+	inline Vec operator*(Vec lhs, const Quat& rhs)
 	{
 		lhs *= rhs;
 		return lhs;
 	}
 
-	Vec Vec::operator-() const
+	inline Vec Vec::operator-() const
 	{
 		Vec result = Vec(-x, -y, -z);
 		return result;
 	}
 
-	float Vec::Dot(const Vec& other) const
+	inline float Vec::Dot(const Vec& other) const
 	{
 		return x * other.x + y * other.y + z * other.z;
 	}
 
-	Vec Vec::Cross(const Vec& other) const
+	inline Vec Vec::Cross(const Vec& other) const
 	{
 		return Vec(y * other.z - z * other.y,
 			z * other.x - x * other.z,
 			x * other.y - y * other.x);
 	}
 
-	Vec Vec::Min(const Vec& other) const
+	inline Vec Vec::Min(const Vec& other) const
 	{
 		return Vec(x < other.x ? x : other.x,
 			y < other.y ? y : other.y,
 			z < other.z ? z : other.z);
 	}
 	
-	Vec Vec::Max(const Vec& other) const
+	inline Vec Vec::Max(const Vec& other) const
 	{
 		return Vec(x > other.x ? x : other.x,
 			y > other.y ? y : other.y,
 			z > other.z ? z : other.z);
 	}
 
-	Vec Vec::Abs() const
+	inline Vec Vec::Abs() const
 	{
 		return Vec(x > 0 ? x : -x,
 			y > 0 ? y : -y,
 			z > 0 ? z : -z);
 	}
 
-	Vec Vec::Lerp(const Vec& other, float factor) const
+	inline Vec Vec::Lerp(const Vec& other, float factor) const
 	{
 		return *this + (other - *this) * factor;
 	}
 
-	Vec Vec::Lerp(const Vec& other, const Vec& factor) const
+	inline Vec Vec::Lerp(const Vec& other, const Vec& factor) const
 	{
 		return Vec(this->x + (other.x - this->x) * factor.x,
 			this->y + (other.y - this->y) * factor.y,
 			this->z + (other.z - this->z) * factor.z);
 	}
 
-	Motion::Motion()
+	inline Motion::Motion()
 	{
 		Reset();
 	}
 
-	void Motion::Reset()
+	inline void Motion::Reset()
 	{
 		Quaternion.Set(1.f, 0.f, 0.f, 0.f);
 		Accel.Set(0.f, 0.f, 0.f);
@@ -543,7 +543,7 @@ namespace GamepadMotionHelpers
 	/// <summary>
 	/// The gyro inputs should be calibrated degrees per second but have no other processing. Acceleration is in G units (1 = approx. 9.8m/s^2)
 	/// </summary>
-	void Motion::Update(float inGyroX, float inGyroY, float inGyroZ, float inAccelX, float inAccelY, float inAccelZ, float gravityLength, float deltaTime)
+	inline void Motion::Update(float inGyroX, float inGyroY, float inGyroZ, float inAccelX, float inAccelY, float inAccelZ, float gravityLength, float deltaTime)
 	{
 		if (!Settings)
 		{
@@ -642,23 +642,23 @@ namespace GamepadMotionHelpers
 		Quaternion.Normalize();
 	}
 
-	void Motion::SetSettings(GamepadMotionSettings* settings)
+	inline void Motion::SetSettings(GamepadMotionSettings* settings)
 	{
 		Settings = settings;
 	}
 
-	SensorMinMaxWindow::SensorMinMaxWindow()
+	inline SensorMinMaxWindow::SensorMinMaxWindow()
 	{
 		Reset(0.f);
 	}
 
-	void SensorMinMaxWindow::Reset(float remainder)
+	inline void SensorMinMaxWindow::Reset(float remainder)
 	{
 		NumSamples = 0;
 		TimeSampled = remainder;
 	}
 
-	void SensorMinMaxWindow::AddSample(const Vec& inGyro, const Vec& inAccel, float deltaTime)
+	inline void SensorMinMaxWindow::AddSample(const Vec& inGyro, const Vec& inAccel, float deltaTime)
 	{
 		if (NumSamples == 0)
 		{
@@ -689,19 +689,19 @@ namespace GamepadMotionHelpers
 		MeanAccel += delta * (1.f / NumSamples);
 	}
 
-	Vec SensorMinMaxWindow::GetMidGyro()
+	inline Vec SensorMinMaxWindow::GetMidGyro()
 	{
 		return MeanGyro;
 	}
 
-	AutoCalibration::AutoCalibration()
+	inline AutoCalibration::AutoCalibration()
 	{
 		CalibrationData = nullptr;
 		MinMaxWindow.TimeSampled = 0.f;
 		TimeSteadyStillness = 0.f;
 	}
 
-	bool AutoCalibration::AddSampleStillness(const Vec& inGyro, const Vec& inAccel, float deltaTime, bool doSensorFusion)
+	inline bool AutoCalibration::AddSampleStillness(const Vec& inGyro, const Vec& inAccel, float deltaTime, bool doSensorFusion)
 	{
 		if (inGyro.x == 0.f && inGyro.y == 0.f && inGyro.z == 0.f &&
 			inAccel.x == 0.f && inAccel.y == 0.f && inAccel.z == 0.f)
@@ -853,12 +853,12 @@ namespace GamepadMotionHelpers
 		return calibrated;
 	}
 
-	void AutoCalibration::NoSampleStillness()
+	inline void AutoCalibration::NoSampleStillness()
 	{
 		MinMaxWindow.Reset(0.f);
 	}
 
-	bool AutoCalibration::AddSampleSensorFusion(const Vec& inGyro, const Vec& inAccel, float deltaTime)
+	inline bool AutoCalibration::AddSampleSensorFusion(const Vec& inGyro, const Vec& inAccel, float deltaTime)
 	{
 		if (deltaTime <= 0.f)
 		{
@@ -994,7 +994,7 @@ namespace GamepadMotionHelpers
 		return calibrated;
 	}
 
-	void AutoCalibration::NoSampleSensorFusion()
+	inline void AutoCalibration::NoSampleSensorFusion()
 	{
 		TimeSteadySensorFusion = 0.f;
 		SensorFusionSkippedTime = 0.f;
@@ -1004,19 +1004,19 @@ namespace GamepadMotionHelpers
 		SmoothedAngularVelocityAccel = GamepadMotionHelpers::Vec();
 	}
 
-	void AutoCalibration::SetCalibrationData(GyroCalibration* calibrationData)
+	inline void AutoCalibration::SetCalibrationData(GyroCalibration* calibrationData)
 	{
 		CalibrationData = calibrationData;
 	}
 
-	void AutoCalibration::SetSettings(GamepadMotionSettings* settings)
+	inline void AutoCalibration::SetSettings(GamepadMotionSettings* settings)
 	{
 		Settings = settings;
 	}
 
 } // namespace GamepadMotionHelpers
 
-GamepadMotion::GamepadMotion()
+inline GamepadMotion::GamepadMotion()
 {
 	IsCalibrating = false;
 	CurrentCalibrationMode = GamepadMotionHelpers::CalibrationMode::Manual;
@@ -1026,7 +1026,7 @@ GamepadMotion::GamepadMotion()
 	Motion.SetSettings(&Settings);
 }
 
-void GamepadMotion::Reset()
+inline void GamepadMotion::Reset()
 {
 	GyroCalibration = {};
 	Gyro = {};
@@ -1035,7 +1035,7 @@ void GamepadMotion::Reset()
 	Motion.Reset();
 }
 
-void GamepadMotion::ProcessMotion(float gyroX, float gyroY, float gyroZ,
+inline void GamepadMotion::ProcessMotion(float gyroX, float gyroY, float gyroZ,
 	float accelX, float accelY, float accelZ, float deltaTime)
 {
 	if (gyroX == 0.f && gyroY == 0.f && gyroZ == 0.f &&
@@ -1090,28 +1090,28 @@ void GamepadMotion::ProcessMotion(float gyroX, float gyroY, float gyroZ,
 }
 
 // reading the current state
-void GamepadMotion::GetCalibratedGyro(float& x, float& y, float& z)
+inline void GamepadMotion::GetCalibratedGyro(float& x, float& y, float& z)
 {
 	x = Gyro.x;
 	y = Gyro.y;
 	z = Gyro.z;
 }
 
-void GamepadMotion::GetGravity(float& x, float& y, float& z)
+inline void GamepadMotion::GetGravity(float& x, float& y, float& z)
 {
 	x = Motion.Grav.x;
 	y = Motion.Grav.y;
 	z = Motion.Grav.z;
 }
 
-void GamepadMotion::GetProcessedAcceleration(float& x, float& y, float& z)
+inline void GamepadMotion::GetProcessedAcceleration(float& x, float& y, float& z)
 {
 	x = Motion.Accel.x;
 	y = Motion.Accel.y;
 	z = Motion.Accel.z;
 }
 
-void GamepadMotion::GetOrientation(float& w, float& x, float& y, float& z)
+inline void GamepadMotion::GetOrientation(float& w, float& x, float& y, float& z)
 {
 	w = Motion.Quaternion.w;
 	x = Motion.Quaternion.x;
@@ -1120,28 +1120,28 @@ void GamepadMotion::GetOrientation(float& w, float& x, float& y, float& z)
 }
 
 // gyro calibration functions
-void GamepadMotion::StartContinuousCalibration()
+inline void GamepadMotion::StartContinuousCalibration()
 {
 	IsCalibrating = true;
 }
 
-void GamepadMotion::PauseContinuousCalibration()
+inline void GamepadMotion::PauseContinuousCalibration()
 {
 	IsCalibrating = false;
 }
 
-void GamepadMotion::ResetContinuousCalibration()
+inline void GamepadMotion::ResetContinuousCalibration()
 {
 	GyroCalibration = {};
 }
 
-void GamepadMotion::GetCalibrationOffset(float& xOffset, float& yOffset, float& zOffset)
+inline void GamepadMotion::GetCalibrationOffset(float& xOffset, float& yOffset, float& zOffset)
 {
 	float accelMagnitude;
 	GetCalibratedSensor(xOffset, yOffset, zOffset, accelMagnitude);
 }
 
-void GamepadMotion::SetCalibrationOffset(float xOffset, float yOffset, float zOffset, int weight)
+inline void GamepadMotion::SetCalibrationOffset(float xOffset, float yOffset, float zOffset, int weight)
 {
 	if (GyroCalibration.NumSamples > 1)
 	{
@@ -1158,24 +1158,24 @@ void GamepadMotion::SetCalibrationOffset(float xOffset, float yOffset, float zOf
 	GyroCalibration.Z = zOffset * weight;
 }
 
-GamepadMotionHelpers::CalibrationMode GamepadMotion::GetCalibrationMode()
+inline GamepadMotionHelpers::CalibrationMode GamepadMotion::GetCalibrationMode()
 {
 	return CurrentCalibrationMode;
 }
 
-void GamepadMotion::SetCalibrationMode(GamepadMotionHelpers::CalibrationMode calibrationMode)
+inline void GamepadMotion::SetCalibrationMode(GamepadMotionHelpers::CalibrationMode calibrationMode)
 {
 	CurrentCalibrationMode = calibrationMode;
 }
 
-void GamepadMotion::ResetMotion()
+inline void GamepadMotion::ResetMotion()
 {
 	Motion.Reset();
 }
 
 // Private Methods
 
-void GamepadMotion::PushSensorSamples(float gyroX, float gyroY, float gyroZ, float accelMagnitude)
+inline void GamepadMotion::PushSensorSamples(float gyroX, float gyroY, float gyroZ, float accelMagnitude)
 {
 	// accumulate
 	GyroCalibration.NumSamples++;
@@ -1185,7 +1185,7 @@ void GamepadMotion::PushSensorSamples(float gyroX, float gyroY, float gyroZ, flo
 	GyroCalibration.AccelMagnitude += accelMagnitude;
 }
 
-void GamepadMotion::GetCalibratedSensor(float& gyroOffsetX, float& gyroOffsetY, float& gyroOffsetZ, float& accelMagnitude)
+inline void GamepadMotion::GetCalibratedSensor(float& gyroOffsetX, float& gyroOffsetY, float& gyroOffsetZ, float& accelMagnitude)
 {
 	if (GyroCalibration.NumSamples <= 0)
 	{


### PR DESCRIPTION
While attempting to diagnose why JoyShockMapper wouldn't build with the JoyShockLibrary version under Linux, I found that the program would not link thanks to multiple definition errors between JoyshockMapper and JoyshockLibrary.

This request inlines all available functions, which should prevent multiple definition errors in the future.

This appears to work properly with Linux JoyShockMapper built in JoyshockLibrary mode, but I would always recommend some additional testing on other platforms before merging.